### PR TITLE
README: Remove advanced javascript note for Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Reactive Flows is a demo project showing a Reactive web app built with:
 
 ## Usage
 
-- Important: Reactive Flows makes use of [advanced JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) which isn't yet available in Chrome, so make sure to use Firefox or Safari
 - To run the first node, execute `rf1` in an sbt session; you can shutdown the app with `reStop`
 - To run further nodes, execute `sbt rf2` or `sbt rf3` from the command line; stop the app with `CTRL+C`
 - As the names and labels of the flows aren't persisted, you have to create them after the app has started; see below examples


### PR DESCRIPTION
Chrome also supports Javascript arrays. Therefor the note in the README can be removed.