### PR TITLE
Fix ConstructrExtension class path

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -30,7 +30,7 @@ akka {
   extensions = [
     akka.cluster.ddata.DistributedData,
     akka.persistence.Persistence,
-    de.heikoseeberger.constructr.akka.ConstructrExtension
+    de.heikoseeberger.constructr.ConstructrExtension
   ]
 
   persistence {


### PR DESCRIPTION
I application.conf, the path to ConstructorExtension is:
`de.heikoseeberger.constructr.akka.ConstructrExtension` instead of `e.heikoseeberger.constructr.ConstructrExtension`
